### PR TITLE
fix: Flatten lowers field keys

### DIFF
--- a/gofig.go
+++ b/gofig.go
@@ -166,7 +166,7 @@ func flatten(rv reflect.Value, rt reflect.Type, key string, fields map[string]re
 			case reflect.Struct:
 				flatten(fv, ft.Type, name, fields)
 			default:
-				fields[name] = fv
+				fields[strings.ToLower(name)] = fv
 			}
 		}
 	}


### PR DESCRIPTION
While flattening, names are kept as they originally were, but when parsing, they it is assumed they have been [lower-cased](https://github.com/krak3n/gofig/blob/master/gofig.go#L74-L75).
